### PR TITLE
Add a new ENABLE_BACKLIGHT command for enabling and disabling the display backlight

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.2.2:
     - Add a method to enable or disable screen auto-rotate
     - Deprecate `WhiteScreen` in favor of `BlankScreen`
+    - Add a method to enable or disable the display backlight
 
 1.2.1:
     - Integrate font in control instruction for TextDrawing

--- a/pygyw/bluetooth/commands.py
+++ b/pygyw/bluetooth/commands.py
@@ -22,7 +22,8 @@ class ControlCodes:
         DISPLAY_TEXT: Send text to the display.
         CLEAR: Clear the screen.
         SET_FONT: Set the font used to display text.
-        AUTO_ROTATE_SCREEN: Enables or disables the screen autorotation.
+        AUTO_ROTATE_SCREEN: Enable or disable the screen autorotation.
+        ENABLE_BACKLIGHT: Enable or disable the display backlight.
 
     """
 
@@ -32,6 +33,7 @@ class ControlCodes:
     CLEAR = 0x05
     SET_FONT = 0x08
     AUTO_ROTATE_SCREEN = 0x0A
+    ENABLE_BACKLIGHT = 0x0B
 
 
 class BTCommand:

--- a/pygyw/bluetooth/device.py
+++ b/pygyw/bluetooth/device.py
@@ -202,7 +202,7 @@ class BTDevice:
 
     async def enable_backlight(self, enable: bool, sleep_time: float = 0.5):
         """
-        Enables or disables the display backlight.
+        Enable or disable the display backlight.
 
         :param sleep_time: Time to wait after having changed the backlight. Defaults to 0.5.
         :type sleep_time: float

--- a/pygyw/bluetooth/device.py
+++ b/pygyw/bluetooth/device.py
@@ -199,3 +199,22 @@ class BTDevice:
                 bytearray([commands.ControlCodes.AUTO_ROTATE_SCREEN, int(enable)]),
             ),
         ])
+
+    async def enable_backlight(self, enable: bool, sleep_time: float = 0.5):
+        """
+        Enables or disables the display backlight.
+
+        :param sleep_time: Time to wait after having changed the backlight. Defaults to 0.5.
+        :type sleep_time: float
+        :param enable: True to enable the backlight, False to disable it.
+        :type enable: bool
+
+        """
+
+        await self.__execute_commands([
+            commands.BTCommand(
+                commands.GYWCharacteristics.DISPLAY_COMMAND,
+                bytearray([commands.ControlCodes.ENABLE_BACKLIGHT, enable]),
+            ),
+        ])
+        await asyncio.sleep(sleep_time)


### PR DESCRIPTION
The new bluetooth command is `KOPIN_BT_ENABLE_BACKLIGHT` and it enables or disables the display backlight depending on its boolean argument.