### PR TITLE
Deprecate command delays

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.2.3:
+    - Deprecate command delays and change their default value to 0
+
 1.2.2:
     - Add a method to get the firmware version
     - Add a method to enable or disable screen auto-rotate

--- a/pygyw/bluetooth/device.py
+++ b/pygyw/bluetooth/device.py
@@ -140,15 +140,11 @@ class BTDevice:
         for drawing in drawings:
             await self.send_drawing(drawing)
 
-    async def start_display(self, sleep_time: float = 0.5):
+    async def start_display(self):
         """
         Turn the screen on.
 
         ..note It has no effect if the screen is already on.
-
-        :param sleep_time: Time to wait after having switched on the screen. Defaults to 0.5.
-        :type sleep_time: float
-
         """
 
         await self.__execute_commands([
@@ -157,16 +153,13 @@ class BTDevice:
                 bytearray([commands.ControlCodes.START_DISPLAY]),
             ),
         ])
-        await asyncio.sleep(sleep_time)
 
-    async def set_contrast(self, value: float, sleep_time: float = 0.1):
+    async def set_contrast(self, value: float):
         """
         Set the screen contrast.
 
         :param value: The contrast value (between 0 and 1).
         :type value: float
-        :param sleep_time: Time to wait after having set up the contrast. Defaults to 0.1.
-        :type sleep_time: float
 
         """
         assert 0 <= value <= 1
@@ -178,16 +171,12 @@ class BTDevice:
             ),
         ])
 
-        await asyncio.sleep(sleep_time)
-
-    async def set_brightness(self, value: float, sleep_time: float = 0.1):
+    async def set_brightness(self, value: float):
         """
         Set the screen brightness.
 
         :param value: The brightness value (between 0 and 1).
         :type value: float
-        :param sleep_time: Time to wait after having set up the brightness. Defaults to 0.1.
-        :type sleep_time: float
 
         """
         assert 0 <= value <= 1
@@ -199,16 +188,12 @@ class BTDevice:
             ),
         ])
 
-        await asyncio.sleep(sleep_time)
-
-    async def set_font(self, font: fonts.GYWFont, sleep_time: float = 0.1):
+    async def set_font(self, font: fonts.GYWFont):
         """
         Set the default font.
 
         :param font: The font to use as default
         :type font: `font.GYWFont`
-        :param sleep_time: Time to wait after having set up the font. Defaults to 0.1.
-        :type sleep_time: float
 
         """
 
@@ -222,8 +207,6 @@ class BTDevice:
                 bytearray([commands.ControlCodes.SET_FONT]),
             ),
         ])
-
-        await asyncio.sleep(sleep_time)
 
         # Save font
         self.font = font
@@ -255,12 +238,10 @@ class BTDevice:
             patch=int(patch),
         )
 
-    async def enable_backlight(self, enable: bool, sleep_time: float = 0.5):
+    async def enable_backlight(self, enable: bool):
         """
         Enable or disable the display backlight.
 
-        :param sleep_time: Time to wait after having changed the backlight. Defaults to 0.5.
-        :type sleep_time: float
         :param enable: True to enable the backlight, False to disable it.
         :type enable: bool
 
@@ -272,4 +253,3 @@ class BTDevice:
                 bytearray([commands.ControlCodes.ENABLE_BACKLIGHT, enable]),
             ),
         ])
-        await asyncio.sleep(sleep_time)

--- a/pygyw/bluetooth/device.py
+++ b/pygyw/bluetooth/device.py
@@ -6,6 +6,7 @@ from bleak.exc import BleakError
 
 from . import commands, exceptions
 from .firmware_version import FirmwareVersion
+from ..deprecated_param import deprecated_param
 from ..layout import drawings, fonts
 
 
@@ -140,11 +141,16 @@ class BTDevice:
         for drawing in drawings:
             await self.send_drawing(drawing)
 
-    async def start_display(self):
+    @deprecated_param("sleep_time", "Delay is no longer needed")
+    async def start_display(self, sleep_time: float = 0.0):
         """
         Turn the screen on.
 
         ..note It has no effect if the screen is already on.
+
+        :param sleep_time: Time to wait after having switched on the screen. Defaults to 0.0.
+        :type sleep_time: float
+
         """
 
         await self.__execute_commands([
@@ -153,13 +159,18 @@ class BTDevice:
                 bytearray([commands.ControlCodes.START_DISPLAY]),
             ),
         ])
+        if sleep_time > 0:
+            await asyncio.sleep(sleep_time)
 
-    async def set_contrast(self, value: float):
+    @deprecated_param("sleep_time", "Delay is no longer needed")
+    async def set_contrast(self, value: float, sleep_time: float = 0.0):
         """
         Set the screen contrast.
 
         :param value: The contrast value (between 0 and 1).
         :type value: float
+        :param sleep_time: Time to wait after having set up the contrast. Defaults to 0.0.
+        :type sleep_time: float
 
         """
         assert 0 <= value <= 1
@@ -171,12 +182,18 @@ class BTDevice:
             ),
         ])
 
-    async def set_brightness(self, value: float):
+        if sleep_time > 0:
+            await asyncio.sleep(sleep_time)
+
+    @deprecated_param("sleep_time", "Delay is no longer needed")
+    async def set_brightness(self, value: float, sleep_time: float = 0.0):
         """
         Set the screen brightness.
 
         :param value: The brightness value (between 0 and 1).
         :type value: float
+        :param sleep_time: Time to wait after having set up the brightness. Defaults to 0.0.
+        :type sleep_time: float
 
         """
         assert 0 <= value <= 1
@@ -188,12 +205,18 @@ class BTDevice:
             ),
         ])
 
-    async def set_font(self, font: fonts.GYWFont):
+        if sleep_time > 0:
+            await asyncio.sleep(sleep_time)
+
+    @deprecated_param("sleep_time", "Delay is no longer needed")
+    async def set_font(self, font: fonts.GYWFont, sleep_time: float = 0.0):
         """
         Set the default font.
 
         :param font: The font to use as default
         :type font: `font.GYWFont`
+        :param sleep_time: Time to wait after having set up the font. Defaults to 0.0.
+        :type sleep_time: float
 
         """
 
@@ -207,6 +230,9 @@ class BTDevice:
                 bytearray([commands.ControlCodes.SET_FONT]),
             ),
         ])
+
+        if sleep_time > 0:
+            await asyncio.sleep(sleep_time)
 
         # Save font
         self.font = font
@@ -238,10 +264,13 @@ class BTDevice:
             patch=int(patch),
         )
 
-    async def enable_backlight(self, enable: bool):
+    @deprecated_param("sleep_time", "Delay is no longer needed")
+    async def enable_backlight(self, enable: bool, sleep_time: float = 0.0):
         """
         Enable or disable the display backlight.
 
+        :param sleep_time: Time to wait after having changed the backlight. Defaults to 0.0.
+        :type sleep_time: float
         :param enable: True to enable the backlight, False to disable it.
         :type enable: bool
 
@@ -253,3 +282,5 @@ class BTDevice:
                 bytearray([commands.ControlCodes.ENABLE_BACKLIGHT, enable]),
             ),
         ])
+        if sleep_time > 0:
+            await asyncio.sleep(sleep_time)

--- a/pygyw/deprecated_param.py
+++ b/pygyw/deprecated_param.py
@@ -1,0 +1,17 @@
+import warnings
+
+
+class deprecated_param:
+    def __init__(self, deprecated_args, reason):
+        self.deprecated_args = set(deprecated_args.split())
+        self.reason = reason
+
+    def __call__(self, callable):
+        def wrapper(*args, **kwargs):
+            found = self.deprecated_args.intersection(kwargs)
+            if found:
+                msg = "Parameter(s) %s deprecated; %s" % (', '.join(map("'{}'".format, found)), self.reason)
+                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+            return callable(*args, **kwargs)
+
+        return wrapper


### PR DESCRIPTION
Deprecate command delays and set their default value to 0 because they are no longer needed.