### PR TITLE
Deprecate set font command in favor of `TextDrawing`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 1.2.3:
     - Deprecate command delays and change their default value to 0
+    - Deprecate `set_font` in favor of `TextDrawing`
 
 1.2.2:
     - Add a method to get the firmware version

--- a/pygyw/bluetooth/device.py
+++ b/pygyw/bluetooth/device.py
@@ -3,6 +3,7 @@ import asyncio
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
+from typing_extensions import deprecated
 
 from . import commands, exceptions
 from .firmware_version import FirmwareVersion
@@ -208,6 +209,7 @@ class BTDevice:
         if sleep_time > 0:
             await asyncio.sleep(sleep_time)
 
+    @deprecated("Set the font when drawing text with `TextDrawing`")
     @deprecated_param("sleep_time", "Delay is no longer needed")
     async def set_font(self, font: fonts.GYWFont, sleep_time: float = 0.0):
         """


### PR DESCRIPTION
`TextDrawing` now has 2 new parameters, the font size and color, replacing the `set_font` command.