### PR TITLE
Declare subpackages and icons in setup script

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.2.3:
     - Deprecate command delays and change their default value to 0
     - Deprecate `set_font` in favor of `TextDrawing`
+    - Fix missing declarations of subpackages and icons in the setup script
 
 1.2.2:
     - Add a method to get the firmware version

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,14 @@ setup(
     author='Antoine Malherbe',
     author_email='a.malherbe@getyourway.be',
     license='BSD 3-clause',
-    packages=['pygyw'],
+    packages=[
+        'pygyw',
+        'pygyw.bluetooth',
+        'pygyw.layout'
+    ],
+    package_data={
+        'pygyw.layout': ['icons/*'],
+    },
     install_requires=[
         'bleak',
     ],


### PR DESCRIPTION
Pip didn't install all the required files because these declarations were missing from the setup script.