### PR TITLE
Handle `BleakDeviceNotFound` errors on connection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
     - Deprecate `set_font` in favor of `TextDrawing`
     - Fix missing declarations of subpackages and icons in the setup script
     - Add an example script to show how to use the library
+    - Handle `BleakDeviceNotFound` errors on connection
 
 1.2.2:
     - Add a method to get the firmware version

--- a/pygyw/bluetooth/device.py
+++ b/pygyw/bluetooth/device.py
@@ -2,7 +2,7 @@ import asyncio
 
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
-from bleak.exc import BleakError
+from bleak.exc import BleakError, BleakDeviceNotFoundError
 from typing_extensions import deprecated
 
 from . import commands, exceptions
@@ -59,7 +59,10 @@ class BTDevice:
 
         print(f"Connecting to {self.device}")
         client = BleakClient(self.device, timeout=5.0, loop=loop)
-        await client.connect()
+        try:
+            await client.connect()
+        except BleakDeviceNotFoundError:
+            return False
 
         connected = client.is_connected
         if connected:


### PR DESCRIPTION
Before that change, when a device was not found an error was thrown. Now, connect method simply returns false.