### PR TITLE
Handle `IconDrawing` and `TextDrawing` that has no data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
     - Add an example script to show how to use the library
     - Replace PNG icons with SVGs and add a scaling factor
     - Handle `BleakDeviceNotFound` errors on connection
+    - Handle `IconDrawing` and `TextDrawing` that has no data
 
 1.2.2:
     - Add a method to get the firmware version

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -183,6 +183,9 @@ class TextDrawing(GYWDrawing):
 
         operations = super().to_commands()
 
+        if not self.text:
+            return operations
+
         # Generate control instruction
         ctrl_data = bytearray([commands.ControlCodes.DISPLAY_TEXT])
         ctrl_data += self.left.to_bytes(4, 'little')
@@ -264,6 +267,11 @@ class IconDrawing(GYWDrawing):
 
         """
 
+        operations = super().to_commands()
+
+        if not self.icon:
+            return operations
+
         left = self.left.to_bytes(4, 'little')
         top = self.top.to_bytes(4, 'little')
         ctrl_data = bytearray([commands.ControlCodes.DISPLAY_IMAGE]) + left + top
@@ -287,7 +295,6 @@ class IconDrawing(GYWDrawing):
 
         ctrl_data += scale.to_bytes(1, 'little', signed=True)
 
-        operations = super().to_commands()
         operations.extend([
             commands.BTCommand(
                 commands.GYWCharacteristics.DISPLAY_DATA,


### PR DESCRIPTION
Before that PR, erroneous drawings that have no data triggered errors. Now their processing is simply skipped.