### PR TITLE
Add support for wrapping TextDrawings on multiple lines

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
     - Replace PNG icons with SVGs and add a scaling factor
     - Handle `BleakDeviceNotFound` errors on connection
     - Handle `IconDrawing` and `TextDrawing` that has no data
+    - Add support for wrapping TextDrawings on multiple lines
 
 1.2.2:
     - Add a method to get the firmware version

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -185,6 +185,13 @@ class TextDrawing(GYWDrawing):
 
     @property
     def wrapped_text(self):
+        """
+        Returns the text wrapped on multiple lines constrained by `max_width` and `max_lines`.
+
+        :return: The wrapped text.
+        :rtype: str
+
+        """
         return "\n".join(self._wrap_text())
 
     def to_commands(self) -> list[commands.BTCommand]:
@@ -241,8 +248,6 @@ class TextDrawing(GYWDrawing):
         :rtype: `list[commands.BTCommand]`
 
         """
-        operations = []
-
         # Generate control instruction
         ctrl_data = bytearray([commands.ControlCodes.DISPLAY_TEXT])
         ctrl_data += self.left.to_bytes(4, 'little')
@@ -256,7 +261,7 @@ class TextDrawing(GYWDrawing):
 
         ctrl_data += bytes(short_color, 'utf-8')
 
-        operations.extend([
+        return [
             # Text data
             commands.BTCommand(
                 commands.GYWCharacteristics.DISPLAY_DATA,
@@ -267,9 +272,7 @@ class TextDrawing(GYWDrawing):
                 commands.GYWCharacteristics.DISPLAY_COMMAND,
                 ctrl_data,
             ),
-        ])
-
-        return operations
+        ]
 
 
 class IconDrawing(GYWDrawing):

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -128,11 +128,15 @@ class TextDrawing(GYWDrawing):
     """
     Represents a text element displayed on the screen.
 
-    Attributes: text: The text to display. left: The horizontal offset (from the left). top: The vertical offset (
-    from the top). font: The font to use for the text (can be None). size: The font size. color: The text color.
-    max_width: The maximum width (in pixels) of the text. It will be wrapped on multiple lines if it is too long.
-    max_lines: The maximum number of lines the text can be wrapped on. All extra lines will be ignored.
-    The value 0 is special and disables the limit.
+    Attributes:
+        text: The text to display.
+        left: The horizontal offset (from the left).
+        top: The vertical offset (from the top).
+        font: The font to use for the text (can be None).
+        size: The font size. color: The text color.
+        max_width: The maximum width (in pixels) of the text. It will be wrapped on multiple lines if it is too long.
+        max_lines: The maximum number of lines the text can be wrapped on. All extra lines will be ignored.
+            The value 0 is special and disables the limit.
     """
 
     def __init__(self,

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -136,8 +136,7 @@ class TextDrawing(GYWDrawing):
         size: The font size.
         color: The text color.
         max_width: The maximum width (in pixels) of the text. It will be wrapped on multiple lines if it is too long.
-        max_lines: The maximum number of lines the text can be wrapped on. All extra lines will be ignored.
-            The value 0 is special and disables the limit.
+        max_lines: The maximum number of lines the text can be wrapped on. All extra lines will be ignored. The value 0 is special and disables the limit.
     """
 
     def __init__(self,

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -133,7 +133,8 @@ class TextDrawing(GYWDrawing):
         left: The horizontal offset (from the left).
         top: The vertical offset (from the top).
         font: The font to use for the text (can be None).
-        size: The font size. color: The text color.
+        size: The font size.
+        color: The text color.
         max_width: The maximum width (in pixels) of the text. It will be wrapped on multiple lines if it is too long.
         max_lines: The maximum number of lines the text can be wrapped on. All extra lines will be ignored.
             The value 0 is special and disables the limit.


### PR DESCRIPTION
2 new optional attributes have been added: `max_width` and `max_lines` which lets you wrap a `TextDrawing` on multiple lines.

The wrapped text can be accessed by applications using the `wrapped_text` property.