### PR TITLE
Add a new command for drawing colored rectangles and partially clearing the screen

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 1.2.4:
     - Remove `get_firmware_version` method
+    - Add a new command for drawing colored rectangles and partially clearing the screen
 
 1.2.3:
     - Deprecate command delays and change their default value to 0

--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ To change the size of the icon, you can use the `scale` parameter. It's an optio
 A `RectangleDrawing` object is used to draw rectangles on the screen. You can create a `RectangleDrawing` object like this:
 
 ```python
-from pygyw.layout import drawings, icons
+from pygyw.layout import drawings
 
-icon = icons.GYWIcons.LEFT
 rd = drawings.RectangleDrawing(left=100, top=200, width=50, height=70, color="ff0000ff")
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ The position of the rectangle can be specified with the `left` and `top` propert
 
 The size of the rectangle can be specified with the `width` and `height` properties.
 
-The color is optional and if not specified, the rectangle will be filled with the current background color, useful for
-erasing parts of the screen.
+The color is optional and if not specified, the rectangle will be filled with the current background color, useful for erasing parts of the screen.
 
 ### Display a drawing on the screen
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ To change the icon displayed, you can use the `icon` parameter, which should be 
 
 To change the size of the icon, you can use the `scale` parameter. It's an optional parameter with a default value of 1.0. If the icon is 48x48, a scale factor of 2.0 will make it 96x96. The scale factor has a range between 0.01 and 13.7. Any scale factor outside of this range will be clamped to the nearest value within the range.
 
+### 4. RectangleDrawing
+
+A `RectangleDrawing` object is used to draw rectangles on the screen. You can create a `RectangleDrawing` object like this:
+
+```python
+from pygyw.layout import drawings, icons
+
+icon = icons.GYWIcons.LEFT
+rd = drawings.RectangleDrawing(left=100, top=200, width=50, height=70, color="ff0000ff")
+```
+
+The position of the rectangle can be specified with the `left` and `top` properties.
+
+The size of the rectangle can be specified with the `width` and `height` properties.
+
+The color is optional and if not specified, the rectangle will be filled with the current background color, useful for
+erasing parts of the screen.
+
 ### Display a drawing on the screen
 
 To display a single drawing use `device.send_drawing(drawing)`.

--- a/pygyw/bluetooth/commands.py
+++ b/pygyw/bluetooth/commands.py
@@ -27,6 +27,7 @@ class ControlCodes:
         SET_FONT: Set the font used to display text.
         AUTO_ROTATE_SCREEN: Enable or disable the screen autorotation.
         ENABLE_BACKLIGHT: Enable or disable the display backlight.
+        DRAW_RECTANGLE: Draw a colored rectangle.
 
     """
 
@@ -39,6 +40,7 @@ class ControlCodes:
     SET_FONT = 0x08
     AUTO_ROTATE_SCREEN = 0x0A
     ENABLE_BACKLIGHT = 0x0B
+    DRAW_RECTANGLE = 0x0C
 
 
 class BTCommand:

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -6,6 +6,7 @@ from typing_extensions import deprecated
 
 from . import fonts
 from . import icons
+from .helpers import rgba8888_bytes_from_color_string
 from .settings import screen_width
 from ..bluetooth import commands
 
@@ -412,7 +413,7 @@ class RectangleDrawing(GYWDrawing):
         top = self.top.to_bytes(2, 'little')
         width = self.width.to_bytes(2, 'little')
         height = self.height.to_bytes(2, 'little')
-        color = str_color_to_rgba8888_bytes(self.color)
+        color = rgba8888_bytes_from_color_string(self.color)
 
         ctrl_data = bytearray([commands.ControlCodes.DRAW_RECTANGLE]) + left + top + width + height + color
 
@@ -424,16 +425,3 @@ class RectangleDrawing(GYWDrawing):
         )
 
         return operations
-
-
-def str_color_to_rgba8888_bytes(color: str) -> bytes:
-    """Transform an ARGB color string into an RGBA8888 byte array of length 4."""
-
-    if color is None:
-        return bytearray([0, 0, 0, 0])
-
-    alpha = int(color[0:2], 16).to_bytes(1, "little")
-    red = int(color[2:4], 16).to_bytes(1, "little")
-    green = int(color[4:6], 16).to_bytes(1, "little")
-    blue = int(color[6:8], 16).to_bytes(1, "little")
-    return red + green + blue + alpha

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -404,7 +404,7 @@ class RectangleDrawing(GYWDrawing):
         return data
 
     def to_commands(self) -> "list[commands.BTCommand]":
-        """Converts this `RectangleDrawing` into a list of commands."""
+        """Convert this `RectangleDrawing` into a list of commands."""
 
         operations = super().to_commands()
 
@@ -427,7 +427,7 @@ class RectangleDrawing(GYWDrawing):
 
 
 def str_color_to_rgba8888_bytes(color: str) -> bytes:
-    """Transforms an ARGB color string into an RGBA8888 byte array of length 4."""
+    """Transform an ARGB color string into an RGBA8888 byte array of length 4."""
 
     if color is None:
         return bytearray([0, 0, 0, 0])

--- a/pygyw/layout/helpers.py
+++ b/pygyw/layout/helpers.py
@@ -193,3 +193,16 @@ def justify(text: str, width: int):
             lines.append(' '.join(line))
 
     return lines
+
+
+def rgba8888_bytes_from_color_string(color: str) -> bytes:
+    """Transform an ARGB color string into an RGBA8888 byte array of length 4."""
+
+    if color is None:
+        return bytearray([0, 0, 0, 0])
+
+    alpha = int(color[0:2], 16).to_bytes(1, "little")
+    red = int(color[2:4], 16).to_bytes(1, "little")
+    green = int(color[4:6], 16).to_bytes(1, "little")
+    blue = int(color[6:8], 16).to_bytes(1, "little")
+    return red + green + blue + alpha


### PR DESCRIPTION
The new `RectangleDrawing` lets you draw colored rectangles on the screen. If the color is not provided, it uses the current background color which is useful for erasing parts of the screen.