### PR TITLE
Avoid dereferencing `self.font` when it's None

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.3.1:
     - Replace setup.py with pyproject.toml
     - Fix position encoding for rectangles and spinners
+    - Default to the medium font to avoid dereferencing None
 
 1.3.0:
     - Remove `get_firmware_version` method

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -215,7 +215,8 @@ class TextDrawing(GYWDrawing):
         if not self.text:
             return operations
 
-        font_size = self.size if self.size is not None else self.font.size
+        font = self.font or fonts.GYWFonts.MEDIUM
+        font_size = self.size or font.size
         char_height = ceil(font_size * 1.33)
 
         commands = []
@@ -238,7 +239,8 @@ class TextDrawing(GYWDrawing):
         else:
             text_width = max_width
 
-        font_size = self.size if self.size is not None else self.font.size
+        font = self.font or fonts.GYWFonts.MEDIUM
+        font_size = self.size or font.size
         char_width = ceil(font_size * 0.6)
         max_chars_per_line = text_width // char_width
 


### PR DESCRIPTION
Default to the medium font if no font has been provided.