### PR TITLE
Encode all positions as signed integers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.3.1:
     - Replace setup.py with pyproject.toml
     - Fix position encoding for rectangles and spinners
+    - Encode positions as signed integers
 
 1.3.0:
     - Remove `get_firmware_version` method

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -258,8 +258,8 @@ class TextDrawing(GYWDrawing):
         """
         # Generate control instruction
         ctrl_data = bytearray([commands.ControlCodes.DISPLAY_TEXT])
-        ctrl_data += self.left.to_bytes(4, 'little')
-        ctrl_data += top.to_bytes(4, 'little')
+        ctrl_data += self.left.to_bytes(4, 'little', signed=True)
+        ctrl_data += top.to_bytes(4, 'little', signed=True)
         ctrl_data += bytes(self.font.prefix if self.font is not None else "NUL", 'utf-8')
         ctrl_data += (self.size if self.size is not None else 0).to_bytes(1, 'little')
 
@@ -340,8 +340,8 @@ class IconDrawing(GYWDrawing):
         if not self.icon:
             return operations
 
-        left = self.left.to_bytes(4, 'little')
-        top = self.top.to_bytes(4, 'little')
+        left = self.left.to_bytes(4, 'little', signed=True)
+        top = self.top.to_bytes(4, 'little', signed=True)
         ctrl_data = bytearray([commands.ControlCodes.DISPLAY_IMAGE]) + left + top
         ctrl_data += bytes(self.color or "NULLNULL", 'utf-8')
         ctrl_data += byte_from_scale_float(self.scale)
@@ -395,8 +395,8 @@ class RectangleDrawing(GYWDrawing):
 
         operations = super().to_commands()
 
-        left = self.left.to_bytes(4, 'little')
-        top = self.top.to_bytes(4, 'little')
+        left = self.left.to_bytes(4, 'little', signed=True)
+        top = self.top.to_bytes(4, 'little', signed=True)
         width = self.width.to_bytes(2, 'little')
         height = self.height.to_bytes(2, 'little')
         color = rgba8888_bytes_from_color_string(self.color)
@@ -469,8 +469,8 @@ class SpinnerDrawing(GYWDrawing):
 
         operations = super().to_commands()
 
-        left = self.left.to_bytes(4, 'little')
-        top = self.top.to_bytes(4, 'little')
+        left = self.left.to_bytes(4, 'little', signed=True)
+        top = self.top.to_bytes(4, 'little', signed=True)
         ctrl_data = bytearray([commands.ControlCodes.DISPLAY_SPINNER]) + left + top
         ctrl_data += rgba8888_bytes_from_color_string(self.color)
         ctrl_data += byte_from_scale_float(self.scale)


### PR DESCRIPTION
Signed positions allow for putting drawings at negative coordinates.