### PR TITLE
Make the library compatible with Python 3.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
     - Replace setup.py with pyproject.toml
     - Fix position encoding for rectangles and spinners
     - Default to the medium font to avoid dereferencing None
+    - Make the library compatible with Python 3.8
 
 1.3.0:
     - Remove `get_firmware_version` method

--- a/pygyw/layout/fonts.py
+++ b/pygyw/layout/fonts.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 
 class GYWFont:
@@ -53,7 +53,7 @@ class GYWFont:
     def __repr__(self) -> str:
         return self.__str__()
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(self) -> Dict[str, Any]:
         """Return a JSON-serializable dictionary of the object."""
 
         return {

--- a/pygyw/layout/icons.py
+++ b/pygyw/layout/icons.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 from . import settings
 
 
@@ -31,7 +31,7 @@ class GYWIcon:
     def __repr__(self) -> str:
         return self.__str__()
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(self) -> Dict[str, Any]:
         """Return a JSON-serializable dictionary of the object."""
 
         return {


### PR DESCRIPTION
The library was supposed to be compatible with Python 3.8 from the beginning but some breaking changes were introduced that weren't tested. This restores the compatibility.