### PR TITLE
Convert legacy font prefixes into meaningful font prefixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
     - Encode positions on 2 bytes instead of 4
     - Convert `BlankScreen` into the `clear_screen` method
     - Update UUIDs of BLE characteristics
+    - Remove font prefixes
 
 1.3.1:
     - Replace setup.py with pyproject.toml

--- a/example.py
+++ b/example.py
@@ -21,7 +21,7 @@ async def main():
     await device.clear_screen("ffffffff")
 
     text = "Hello, world!"
-    font = fonts.GYWFonts.ROBOTO_MONO_NORMAL
+    font = fonts.GYWFonts.ROBOTO_MONO
     text_drawing = drawings.TextDrawing(text=text, left=100, top=100, font=font, size=24, color="ff000000")
     await device.send_drawing(text_drawing)
 

--- a/example.py
+++ b/example.py
@@ -21,12 +21,12 @@ async def main():
     await device.clear_screen("ffffffff")
 
     text = "Hello, world!"
-    font = fonts.GYWFonts.LARGE
-    text_drawing = drawings.TextDrawing(text=text, left=100, top=100, font=font, color="ff000000")
+    font = fonts.GYWFonts.ROBOTO_MONO_NORMAL
+    text_drawing = drawings.TextDrawing(text=text, left=100, top=100, font=font, size=24, color="ff000000")
     await device.send_drawing(text_drawing)
 
     text = "Big green text!"
-    text_drawing = drawings.TextDrawing(text=text, left=100, top=350, size=80, color="ff00ff00")
+    text_drawing = drawings.TextDrawing(text=text, left=100, top=350, font=font, size=80, color="ff00ff00")
     await device.send_drawing(text_drawing)
 
     icon = icons.GYWIcons.HELP

--- a/example.py
+++ b/example.py
@@ -21,12 +21,12 @@ async def main():
     await device.clear_screen("ffffffff")
 
     text = "Hello, world!"
-    font = fonts.GYWFonts.ROBOTO_MONO
+    font = fonts.GYWFonts.ROBOTO_MONO_BOLD
     text_drawing = drawings.TextDrawing(text=text, left=100, top=100, font=font, size=24, color="ff000000")
     await device.send_drawing(text_drawing)
 
     text = "Big green text!"
-    text_drawing = drawings.TextDrawing(text=text, left=100, top=350, font=font, size=80, color="ff00ff00")
+    text_drawing = drawings.TextDrawing(text=text, left=100, top=350, size=80, color="ff00ff00")
     await device.send_drawing(text_drawing)
 
     icon = icons.GYWIcons.HELP

--- a/pygyw/bluetooth/commands.py
+++ b/pygyw/bluetooth/commands.py
@@ -24,7 +24,6 @@ class ControlCodes:
         CLEAR: Clear the screen.
         SET_CONTRAST: Set the screen contrast.
         SET_BRIGHTNESS: Set the screen brightness.
-        SET_FONT: Set the font used to display text.
         AUTO_ROTATE_SCREEN: Enable or disable the screen autorotation.
         ENABLE_BACKLIGHT: Enable or disable the display backlight.
         DRAW_RECTANGLE: Draw a colored rectangle.
@@ -37,7 +36,6 @@ class ControlCodes:
     CLEAR = 0x05
     SET_CONTRAST = 0x06
     SET_BRIGHTNESS = 0x07
-    SET_FONT = 0x08
     AUTO_ROTATE_SCREEN = 0x0A
     ENABLE_BACKLIGHT = 0x0B
     DRAW_RECTANGLE = 0x0C

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -82,10 +82,10 @@ class TextDrawing(GYWDrawing):
 
     def __init__(self,
                  text: str,
-                 font: fonts.GYWFont = fonts.GYWFonts.ROBOTO_MONO,
-                 size: int = 24,
                  left: int = 0,
                  top: int = 0,
+                 font: fonts.GYWFont = fonts.GYWFonts.ROBOTO_MONO,
+                 size: int = 24,
                  color: str = None,
                  max_width: int = None,
                  max_lines: int = 1):

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -82,8 +82,8 @@ class TextDrawing(GYWDrawing):
 
     def __init__(self,
                  text: str,
-                 font: fonts.GYWFont,
-                 size: int,
+                 font: fonts.GYWFont = fonts.GYWFonts.ROBOTO_MONO,
+                 size: int = 24,
                  left: int = 0,
                  top: int = 0,
                  color: str = None,

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -98,9 +98,9 @@ class TextDrawing(GYWDrawing):
         :type left: int
         :param left: The vertical offset. Defaults to 0.
         :type top: int
-        :param font: The font used for the text.
+        :param font: The font used for the text. Defaults to `fonts.GYWFonts.ROBOTO_MONO`.
         :type font: `fonts.GYWFont`
-        :param size: The font size.
+        :param size: The font size. Defaults to 24.
         :type size: int
         :param color: The text color in ORGB format.
         :type color: str

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -73,7 +73,7 @@ class TextDrawing(GYWDrawing):
         text: The text to display.
         left: The horizontal offset (from the left).
         top: The vertical offset (from the top).
-        font: The font to use for the text (can be None).
+        font: The font to use for the text.
         size: The font size.
         color: The text color.
         max_width: The maximum width (in pixels) of the text. It will be wrapped on multiple lines if it is too long.
@@ -82,10 +82,10 @@ class TextDrawing(GYWDrawing):
 
     def __init__(self,
                  text: str,
+                 font: fonts.GYWFont,
+                 size: int,
                  left: int = 0,
                  top: int = 0,
-                 font: fonts.GYWFont = None,
-                 size: int = None,
                  color: str = None,
                  max_width: int = None,
                  max_lines: int = 1):
@@ -98,7 +98,7 @@ class TextDrawing(GYWDrawing):
         :type left: int
         :param left: The vertical offset. Defaults to 0.
         :type top: int
-        :param font: The font used for the text. Defaults to None.
+        :param font: The font used for the text.
         :type font: `fonts.GYWFont`
         :param size: The font size.
         :type size: int
@@ -152,9 +152,7 @@ class TextDrawing(GYWDrawing):
         if not self.text:
             return operations
 
-        font = self.font or fonts.GYWFonts.MEDIUM
-        font_size = self.size or font.size
-        char_height = ceil(font_size * 1.33)
+        char_height = ceil(self.size * 1.33)
 
         commands = []
         current_top = self.top
@@ -176,9 +174,7 @@ class TextDrawing(GYWDrawing):
         else:
             text_width = max_width
 
-        font = self.font or fonts.GYWFonts.MEDIUM
-        font_size = self.size or font.size
-        char_width = ceil(font_size * 0.6)
+        char_width = ceil(self.size * 0.6)
         max_chars_per_line = text_width // char_width
 
         lines = textwrap.wrap(self.text, width=max_chars_per_line)
@@ -199,8 +195,8 @@ class TextDrawing(GYWDrawing):
         ctrl_data = bytearray([commands.ControlCodes.DISPLAY_TEXT])
         ctrl_data += self.left.to_bytes(2, 'little', signed=True)
         ctrl_data += top.to_bytes(2, 'little', signed=True)
-        ctrl_data += bytes(self.font.prefix if self.font is not None else "NUL", 'utf-8')
-        ctrl_data += (self.size if self.size is not None else 0).to_bytes(1, 'little')
+        ctrl_data += bytes(self.font.filename.ljust(5, '\0'), 'utf-8')
+        ctrl_data += self.size.to_bytes(1, 'little')
 
         short_color = "NULL"
         if self.color:

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -195,7 +195,7 @@ class TextDrawing(GYWDrawing):
         ctrl_data = bytearray([commands.ControlCodes.DISPLAY_TEXT])
         ctrl_data += self.left.to_bytes(2, 'little', signed=True)
         ctrl_data += top.to_bytes(2, 'little', signed=True)
-        ctrl_data += bytes(self.font.filename.ljust(5, '\0'), 'utf-8')
+        ctrl_data += bytes(self.font.filename, 'utf-8')
         ctrl_data += self.size.to_bytes(1, 'little')
 
         short_color = "NULL"

--- a/pygyw/layout/fonts.py
+++ b/pygyw/layout/fonts.py
@@ -7,45 +7,26 @@ class GYWFont:
 
     Attributes:
         name: Display name of the font.
-        index: Index of the font on the device.
-        prefix: Prefix used on the device for the font.
-        size: Size of a character in points.
-        height: Height of a character in pixels.
-        width: Width of a character in pixels.
-        bold: Whether the font is in bold or not.
+        filename: Filename of the font on the device.
     """
 
     def __init__(
-        self, name: str, index: int, prefix: str, size: float,
-        height: int, width: int, bold: bool = False,
+            self,
+            name: str,
+            filename: str,
     ):
         """
         Initialize a new `GYWFont` object.
 
         :param name: Display name of the font.
         :type name: str
-        :param index: Index of the font on the device.
-        :type index: int
-        :param prefix: Prefix used on the device for the font.
-        :type prefix: str
-        :param size: Size (in points) of a character.
-        :type size: float
-        :param height: Height (in pixels) of a character.
-        :type height: int
-        :param width: Width (in pixels) of a character.
-        :type width: int
-        :param bold: Whether the font is in bold or not. Defaults to False.
-        :type bold: bool
+        :param filename: Filename of the font on the device.
+        :type filename: str
 
         """
 
         self.name = name
-        self.index = index
-        self.prefix = prefix
-        self.size = size
-        self.height = height
-        self.width = width
-        self.bold = bold
+        self.filename = filename
 
     def __str__(self) -> str:
         return self.name
@@ -57,32 +38,14 @@ class GYWFont:
         """Return a JSON-serializable dictionary of the object."""
 
         return {
-            "title": self.index,
+            "title": self.filename,
         }
 
 
 class GYWFonts:
-    """
-    Active fonts on aRdent smart glasses.
+    """Active fonts on aRdent smart glasses."""
 
-    Attributes:
-        SMALL: A small font
-        MEDIUM: A medium font
-        LARGE: A large font
-        HUGE: A huge font
-        values: List containing every fonts available on aRdent smart glasses.
-    """
+    ROBOTO_MONO_NORMAL = GYWFont(name="Roboto Mono Normal", filename="robmn")
+    ROBOTO_MONO_BOLD = GYWFont(name="Roboto Mono Bold", filename="robmb")
 
-    SMALL = GYWFont(
-        name="Small", index=0, prefix="a10", size=18, width=10, height=25)
-
-    MEDIUM = GYWFont(
-        name="Medium", index=1, prefix="b14", size=24, width=14, height=33, bold=True)
-
-    LARGE = GYWFont(
-        name="Large", index=2, prefix="a16", size=28, width=16, height=39)
-
-    HUGE = GYWFont(
-        name="Huge", index=3, prefix="b28", size=48, width=28, height=67, bold=True)
-
-    values = [SMALL, MEDIUM, LARGE, HUGE]
+    values = [ROBOTO_MONO_NORMAL, ROBOTO_MONO_BOLD]

--- a/pygyw/layout/fonts.py
+++ b/pygyw/layout/fonts.py
@@ -59,7 +59,7 @@ class GYWFonts:
 
     ROBOTO_MONO = GYWFont(name="Roboto Mono", filename="robmn")
     ROBOTO_MONO_BOLD = GYWFont(name="Roboto Mono Bold", filename="robmb", bold=True)
-    ROBOTO_MONO_ITALIC = GYWFont(name="Roboto Mono Italic", filename="robmi", bold=True)
-    ROBOTO_MONO_BOLD_ITALIC = GYWFont(name="Roboto Mono Bold Italic", filename="robmB", bold=True)
+    ROBOTO_MONO_ITALIC = GYWFont(name="Roboto Mono Italic", filename="robmi", italic=True)
+    ROBOTO_MONO_BOLD_ITALIC = GYWFont(name="Roboto Mono Bold Italic", filename="robme", bold=True, italic=True)
 
     values = [ROBOTO_MONO, ROBOTO_MONO_BOLD, ROBOTO_MONO_ITALIC, ROBOTO_MONO_BOLD_ITALIC]

--- a/pygyw/layout/fonts.py
+++ b/pygyw/layout/fonts.py
@@ -45,7 +45,7 @@ class GYWFont:
 class GYWFonts:
     """Active fonts on aRdent smart glasses."""
 
-    ROBOTO_MONO_NORMAL = GYWFont(name="Roboto Mono Normal", filename="robmn")
+    ROBOTO_MONO = GYWFont(name="Roboto Mono", filename="robmn")
     ROBOTO_MONO_BOLD = GYWFont(name="Roboto Mono Bold", filename="robmb")
 
-    values = [ROBOTO_MONO_NORMAL, ROBOTO_MONO_BOLD]
+    values = [ROBOTO_MONO, ROBOTO_MONO_BOLD]

--- a/pygyw/layout/fonts.py
+++ b/pygyw/layout/fonts.py
@@ -7,7 +7,7 @@ class GYWFont:
 
     Attributes:
         name: Display name of the font.
-        filename: Filename of the font on the device.
+        filename: Filename of the font on the device. (5 characters-long and no type extension).
     """
 
     def __init__(
@@ -20,10 +20,12 @@ class GYWFont:
 
         :param name: Display name of the font.
         :type name: str
-        :param filename: Filename of the font on the device.
+        :param filename: Filename of the font on the device. (5 characters-long and no type extension).
         :type filename: str
 
         """
+
+        assert len(filename) == 5, "The filename must be 5 characters long."
 
         self.name = name
         self.filename = filename

--- a/pygyw/layout/fonts.py
+++ b/pygyw/layout/fonts.py
@@ -59,5 +59,7 @@ class GYWFonts:
 
     ROBOTO_MONO = GYWFont(name="Roboto Mono", filename="robmn")
     ROBOTO_MONO_BOLD = GYWFont(name="Roboto Mono Bold", filename="robmb", bold=True)
+    ROBOTO_MONO_ITALIC = GYWFont(name="Roboto Mono Italic", filename="robmi", bold=True)
+    ROBOTO_MONO_BOLD_ITALIC = GYWFont(name="Roboto Mono Bold Italic", filename="robmB", bold=True)
 
-    values = [ROBOTO_MONO, ROBOTO_MONO_BOLD]
+    values = [ROBOTO_MONO, ROBOTO_MONO_BOLD, ROBOTO_MONO_ITALIC, ROBOTO_MONO_BOLD_ITALIC]

--- a/pygyw/layout/fonts.py
+++ b/pygyw/layout/fonts.py
@@ -8,6 +8,7 @@ class GYWFont:
     Attributes:
         name: Display name of the font.
         filename: Filename of the font on the device. (5 characters-long and no type extension).
+        char_width: The width of a character at 1pt.
         bold: Whether the font is bold.
         italic: Whether the font is italic.
     """
@@ -16,6 +17,7 @@ class GYWFont:
             self,
             name: str,
             filename: str,
+            char_width: float = 0.6,
             bold: bool = False,
             italic: bool = False,
     ):
@@ -26,6 +28,8 @@ class GYWFont:
         :type name: str
         :param filename: Filename of the font on the device. (5 characters-long and no type extension).
         :type filename: str
+        :param char_width: The width of a character at 1pt. Defaults to 0.6.
+        :type char_width: float
         :param bold: Whether the font is bold. Defaults to False.
         :type bold: bool
         :param italic: Whether the font is italic. Defaults to False.
@@ -37,6 +41,7 @@ class GYWFont:
 
         self.name = name
         self.filename = filename
+        self.char_width = char_width
         self.bold = bold
         self.italic = italic
 

--- a/pygyw/layout/fonts.py
+++ b/pygyw/layout/fonts.py
@@ -8,12 +8,16 @@ class GYWFont:
     Attributes:
         name: Display name of the font.
         filename: Filename of the font on the device. (5 characters-long and no type extension).
+        bold: Whether the font is bold.
+        italic: Whether the font is italic.
     """
 
     def __init__(
             self,
             name: str,
             filename: str,
+            bold: bool = False,
+            italic: bool = False,
     ):
         """
         Initialize a new `GYWFont` object.
@@ -22,6 +26,10 @@ class GYWFont:
         :type name: str
         :param filename: Filename of the font on the device. (5 characters-long and no type extension).
         :type filename: str
+        :param bold: Whether the font is bold. Defaults to False.
+        :type bold: bool
+        :param italic: Whether the font is italic. Defaults to False.
+        :type italic: bool
 
         """
 
@@ -29,6 +37,8 @@ class GYWFont:
 
         self.name = name
         self.filename = filename
+        self.bold = bold
+        self.italic = italic
 
     def __str__(self) -> str:
         return self.name
@@ -48,6 +58,6 @@ class GYWFonts:
     """Active fonts on aRdent smart glasses."""
 
     ROBOTO_MONO = GYWFont(name="Roboto Mono", filename="robmn")
-    ROBOTO_MONO_BOLD = GYWFont(name="Roboto Mono Bold", filename="robmb")
+    ROBOTO_MONO_BOLD = GYWFont(name="Roboto Mono Bold", filename="robmb", bold=True)
 
     values = [ROBOTO_MONO, ROBOTO_MONO_BOLD]


### PR DESCRIPTION
* Legacy prefixes had no reason to exists anymore. They have been replaced by more meaningful value (yet, limited to 5 characters).
* It is now possible to create custom fonts.
* Default sizes have been removed from font objects, because font size is specified in `TextDrawing` objects.
* Default fonts are `ROBOTO_MONO`, `ROBOTO_MONO_BOLD`, `ROBOTO_MONO_ITALIC`, `ROBOTO_MONO_BOLD_ITALIC`