### PR TITLE
Version bump & Use of flake8 instead of pycodestyle

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+per-file-ignores = __init__.py:F401
+exclude = .git,__pycache__,venv,.venv,build,dist
+ignore = E501

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,4 +1,4 @@
-name: Check code style with pycodestyle
+name: Check code quality with Flake 8
 
 on:
   pull_request:
@@ -17,6 +17,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pycodestyle
-      - name: Run pycodestyle
-        run: pycodestyle --ignore=E501 --count pygyw
+          pip install flake8
+      - name: Run flake8
+        run: flake8 --count .

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.3.2:
     - Write Mode Enhancement: Updated the device.py to utilize "Write Without Response" mode instead of "Write With Response" to improve communication efficiency.
     - Conditional Delay Implementation: Implemented a conditional delay when sending packets, specifically when operating on MacOS, to optimize transmission performance.
+    - Use of flake8 instead of pycodestyle as linter
 
 1.3.1:
     - Replace setup.py with pyproject.toml

--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from pygyw.bluetooth import BTDevice, BTManager
+from pygyw.bluetooth import BTManager
 from pygyw.layout import drawings, fonts, icons
 
 

--- a/pygyw/bluetooth/manager.py
+++ b/pygyw/bluetooth/manager.py
@@ -53,7 +53,7 @@ class BTManager:
             raise BTException("A scan is already in progress")
 
         self.is_scanning = True
-        print(f"Scanning for BLE devices...")
+        print("Scanning for BLE devices...")
 
         device_local_storage = self.__get_device_local_storage()
         try:
@@ -72,7 +72,7 @@ class BTManager:
                     f.write("\n".join(device.address))
 
             if not self.devices:
-                print(f"No BLE device found found...")
+                print("No BLE device found found...")
         finally:
             self.is_scanning = False
 

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -484,7 +484,7 @@ class SpinnerDrawing(GYWDrawing):
         operations.extend([
             commands.BTCommand(
                 commands.GYWCharacteristics.DISPLAY_DATA,
-                bytes(f"spinner_1.svg", 'utf-8'),
+                bytes("spinner_1.svg", 'utf-8'),
             ),
             commands.BTCommand(
                 commands.GYWCharacteristics.DISPLAY_COMMAND,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygyw"
-version = "1.3.1"
+version = "1.3.2"
 requires-python = ">=3.8"
 authors = [
     { name = "Get Your Way" },


### PR DESCRIPTION
* `pycodestyle` is less and less supported by IDE. They are migrating to [flake8](https://flake8.pycqa.org/), which is more complete.
* The version number of the library has also been updated to 1.3.2 through this change