### PR TITLE
Add Flake8 as default linter and fix some leftovers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+per-file-ignores = __init__.py:F401
+exclude = .git,__pycache__,venv,.venv,build,dist,odoo
+ignore = E501

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,8 +1,10 @@
-name: Check code style with pycodestyle
+name: Check code quality with Flake 8
 
 on:
   pull_request:
-    branches: [master, develop]
+    branches: 
+      - master
+      - develop
 
 jobs:
   check_style:
@@ -17,6 +19,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pycodestyle
-      - name: Run pycodestyle
-        run: pycodestyle --ignore=E501 --count pygyw
+          pip install flake8
+      - name: Run flake8
+        run: flake8 --count .

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
     - Update UUIDs of BLE characteristics
     - Remove leftover font and font_optimized fields in BTDevice
     - Remove font prefixes
+    - Add Flake8 as default linter
 
 1.3.1:
     - Replace setup.py with pyproject.toml

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -77,8 +77,10 @@ class TextDrawing(GYWDrawing):
         font: The font to use for the text.
         size: The font size.
         color: The text color.
-        max_width: The maximum width (in pixels) of the text. It will be wrapped on multiple lines if it is too long.
-        max_lines: The maximum number of lines the text can be wrapped on. All extra lines will be ignored. The value 0 is special and disables the limit.
+        max_width: The maximum width (in pixels) of the text.
+                   It will be wrapped on multiple lines if it is too long.
+        max_lines: The maximum number of lines the text can be wrapped on.
+                   All extra lines will be ignored. The value 0 is special and disables the limit.
     """
 
     def __init__(self,
@@ -87,7 +89,7 @@ class TextDrawing(GYWDrawing):
                  top: int = 0,
                  font: fonts.GYWFont = fonts.GYWFonts.ROBOTO_MONO,
                  size: int = 24,
-                 color: str = None,
+                 color: str = Colors.BLACK,
                  max_width: int = None,
                  max_lines: int = 1):
         """
@@ -103,11 +105,11 @@ class TextDrawing(GYWDrawing):
         :type font: `fonts.GYWFont`
         :param size: The font size. Defaults to 24.
         :type size: int
-        :param color: The text color.
+        :param color: The text color. Defaults to `Colors.BLACK`.
         :type color: Color
         :param max_width: The maximum width of the text.
         :type max_width: int
-        :param max_lines: The maximum number of lines the text can be wrapped on.
+        :param max_lines: The maximum number of lines the text can be wrapped on. Defaults to 1.
         :type max_lines: int
         """
 
@@ -286,7 +288,7 @@ class IconDrawing(GYWDrawing):
         operations.extend([
             commands.BTCommand(
                 commands.GYWCharacteristics.DISPLAY_DATA,
-                bytes(f"{self.icon.name}.bin", 'utf-8'),
+                bytes(f"{self.icon.name}.svg", 'utf-8'),
             ),
             commands.BTCommand(
                 commands.GYWCharacteristics.DISPLAY_COMMAND,
@@ -419,7 +421,7 @@ class SpinnerDrawing(GYWDrawing):
         operations.extend([
             commands.BTCommand(
                 commands.GYWCharacteristics.DISPLAY_DATA,
-                bytes(f"spinner_1.svg", 'utf-8'),
+                bytes("spinner_1.svg", 'utf-8'),
             ),
             commands.BTCommand(
                 commands.GYWCharacteristics.DISPLAY_COMMAND,

--- a/pygyw/layout/drawings.py
+++ b/pygyw/layout/drawings.py
@@ -89,7 +89,7 @@ class TextDrawing(GYWDrawing):
                  top: int = 0,
                  font: fonts.GYWFont = fonts.GYWFonts.ROBOTO_MONO,
                  size: int = 24,
-                 color: str = Colors.BLACK,
+                 color: Color = Colors.BLACK,
                  max_width: int = None,
                  max_lines: int = 1):
         """

--- a/pygyw/layout/icons.py
+++ b/pygyw/layout/icons.py
@@ -44,13 +44,6 @@ class GYWIcons:
     All icons currently active on aRdent smart glasses.
 
     Attributes:
-        BLANK: A blank icon that is usually used to remove an icon from the screen.
-        .. image:: icons/blank.svg
-            :width: 48px
-            :height: 48px
-            :alt: Blank icon
-            :align: center
-
         BUILD: An icon representing construction tools.
         .. image:: icons/build.svg
             :width: 48px
@@ -363,7 +356,6 @@ class GYWIcons:
 
     """
 
-    BLANK = GYWIcon("blank")
     BUILD = GYWIcon("build")
     CAMERA = GYWIcon("camera")
     CHAT = GYWIcon("chat")
@@ -410,7 +402,6 @@ class GYWIcons:
     KEY_NUM = GYWIcon("key_#")
 
     values = [
-        BLANK,
         BUILD,
         CAMERA,
         CHAT,


### PR DESCRIPTION
* Use of flake8 instead of pycodestyle for coding style
* Use BLACK as default color in `TextDrawing`
* Remove BLANK icon