### PR TITLE
Enable logging when the environment variable PYGYW_LOGGING is set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
     - Remove leftover font and font_optimized fields in BTDevice
     - Remove font prefixes
     - Add Flake8 as default linter
+    - Enable logging when the environment variable PYGYW_LOGGING is set
 
 1.3.2:
     - Write Mode Enhancement: Updated the device.py to utilize "Write Without Response" mode instead of "Write With Response" to improve communication efficiency.

--- a/pygyw/__init__.py
+++ b/pygyw/__init__.py
@@ -5,11 +5,23 @@ PyGYW is a Python library that provides an easy-to-use interface to control the 
 This library allows you to send instructions to the glasses such as displaying text, icons, or images on the glasses' screen.
 
 """
+from importlib.metadata import version
+import logging
+import os
+import sys
 
 from . import bluetooth
 from . import exceptions
 from . import layout
 
-from importlib.metadata import version
-
 __version__ = version("pygyw")
+
+_logger = logging.getLogger(__name__)
+_logger.addHandler(logging.NullHandler())
+if bool(os.getenv("PYGYW_LOGGING", False)):
+    FORMAT = "%(asctime)-15s %(name)-8s %(threadName)s %(levelname)s: %(message)s"
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter(fmt=FORMAT))
+    _logger.addHandler(handler)
+    _logger.setLevel(logging.DEBUG)

--- a/pygyw/bluetooth/device.py
+++ b/pygyw/bluetooth/device.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import platform
 from typing import Optional
 
@@ -9,6 +10,8 @@ from bleak.exc import BleakError, BleakDeviceNotFoundError
 from . import commands, exceptions
 from ..layout import drawings
 from ..layout.color import Color
+
+logger = logging.getLogger(__name__)
 
 
 class BTDevice:
@@ -41,16 +44,16 @@ class BTDevice:
 
     async def start_notify(self, char_uuid_for_notifications, handler):
         if self.client is not None and self.client.is_connected:
-            print(f"Listening for notifications on UUID: {char_uuid_for_notifications}...")
+            logger.debug(f"Listening for notifications on UUID: {char_uuid_for_notifications}...")
             await self.client.start_notify(char_uuid_for_notifications, handler)
         else:
-            print("Client not connected or not available.")
+            logger.debug("Client not connected or not available.")
 
     async def stop_notify(self, char_uuid):
         if self.client is not None and self.client.is_connected:
             await self.client.stop_notify(char_uuid)
         else:
-            print("Client not connected or not available.")
+            logger.debug("Client not connected or not available.")
 
     async def connect(self, loop: asyncio.AbstractEventLoop = None) -> bool:
         """
@@ -64,7 +67,7 @@ class BTDevice:
 
         """
 
-        print(f"Connecting to {self.device}")
+        logger.debug(f"Connecting to {self.device}")
         client = BleakClient(self.device, timeout=5.0, loop=loop)
         try:
             await client.connect()
@@ -74,9 +77,9 @@ class BTDevice:
         connected = client.is_connected
         if connected:
             self.client = client
-            print(f"Connection to device {self.device} succeeded")
+            logger.debug(f"Connection to device {self.device} succeeded")
         else:
-            print(f"Connection to device {self.device} failed")
+            logger.debug(f"Connection to device {self.device} failed")
 
         return connected
 
@@ -89,10 +92,10 @@ class BTDevice:
 
         """
 
-        print(f"Disconnecting from {self.device} with address: {self.device}")
+        logger.debug(f"Disconnecting from {self.device} with address: {self.device}")
         if not self.client:
             # No connection
-            print("Already disconnected")
+            logger.debug("Already disconnected")
             return True
 
         await self.client.disconnect()
@@ -100,9 +103,9 @@ class BTDevice:
         disconnected = not self.client.is_connected
         if disconnected:
             self.client = None
-            print(f"Disconnection from device {self.device} succeeded")
+            logger.debug(f"Disconnection from device {self.device} succeeded")
         else:
-            print(f"Disconnection from device {self.device} failed")
+            logger.debug(f"Disconnection from device {self.device} failed")
 
         return disconnected
 
@@ -131,11 +134,11 @@ class BTDevice:
         try:
             await self.__execute_commands(commands)
         except BleakError as e:
-            print("Bluetooth Error while sending data: %s" % e)
+            logger.debug("Bluetooth Error while sending data: %s" % e)
             await self.disconnect()
             raise exceptions.BTException("BT Error: %s" % str(e))
         except OSError as e:
-            print("OS Error while sending data: %s" % e)
+            logger.debug("OS Error while sending data: %s" % e)
             await self.disconnect()
             raise exceptions.BTException("OS Error: %s" % str(e))
 

--- a/pygyw/bluetooth/device.py
+++ b/pygyw/bluetooth/device.py
@@ -47,13 +47,13 @@ class BTDevice:
             logger.debug(f"Listening for notifications on UUID: {char_uuid_for_notifications}...")
             await self.client.start_notify(char_uuid_for_notifications, handler)
         else:
-            logger.debug("Client not connected or not available.")
+            logger.warning("Client not connected or not available.")
 
     async def stop_notify(self, char_uuid):
         if self.client is not None and self.client.is_connected:
             await self.client.stop_notify(char_uuid)
         else:
-            logger.debug("Client not connected or not available.")
+            logger.warning("Client not connected or not available.")
 
     async def connect(self, loop: asyncio.AbstractEventLoop = None) -> bool:
         """
@@ -77,9 +77,9 @@ class BTDevice:
         connected = client.is_connected
         if connected:
             self.client = client
-            logger.debug(f"Connection to device {self.device} succeeded")
+            logger.info(f"Connection to device {self.device} succeeded")
         else:
-            logger.debug(f"Connection to device {self.device} failed")
+            logger.warning(f"Connection to device {self.device} failed")
 
         return connected
 
@@ -95,7 +95,7 @@ class BTDevice:
         logger.debug(f"Disconnecting from {self.device} with address: {self.device}")
         if not self.client:
             # No connection
-            logger.debug("Already disconnected")
+            logger.warning("Already disconnected")
             return True
 
         await self.client.disconnect()
@@ -103,9 +103,9 @@ class BTDevice:
         disconnected = not self.client.is_connected
         if disconnected:
             self.client = None
-            logger.debug(f"Disconnection from device {self.device} succeeded")
+            logger.info(f"Disconnection from device {self.device} succeeded")
         else:
-            logger.debug(f"Disconnection from device {self.device} failed")
+            logger.warning(f"Disconnection from device {self.device} failed")
 
         return disconnected
 
@@ -134,13 +134,13 @@ class BTDevice:
         try:
             await self.__execute_commands(commands)
         except BleakError as e:
-            logger.debug("Bluetooth Error while sending data: %s" % e)
+            logger.error(f"Bluetooth Error while sending data: {e}")
             await self.disconnect()
-            raise exceptions.BTException("BT Error: %s" % str(e))
+            raise exceptions.BTException(f"BT Error: {e}")
         except OSError as e:
-            logger.debug("OS Error while sending data: %s" % e)
+            logger.error(f"OS Error while sending data: {e}")
             await self.disconnect()
-            raise exceptions.BTException("OS Error: %s" % str(e))
+            raise exceptions.BTException(f"OS Error: {e}")
 
     async def send_drawings(self, drawings: "list[drawings.GYWDrawing]"):
         """

--- a/pygyw/bluetooth/manager.py
+++ b/pygyw/bluetooth/manager.py
@@ -75,7 +75,7 @@ class BTManager:
                     f.write("\n".join(device.address))
 
             if not self.devices:
-                logger.debug("No BLE device found found...")
+                logger.warning("No BLE device found found...")
         finally:
             self.is_scanning = False
 
@@ -88,7 +88,7 @@ class BTManager:
         device_local_storage = os.path.join(self.__get_device_local_storage(), "devices.txt")
 
         if not os.path.exists(device_local_storage):
-            logger.debug("Device local storage not setup")
+            logger.error("Device local storage not setup")
             return
 
         with open(device_local_storage, "r") as f:

--- a/pygyw/bluetooth/manager.py
+++ b/pygyw/bluetooth/manager.py
@@ -1,10 +1,13 @@
 from bleak import BleakScanner
+import logging
 import os
 import platform
 
 from .exceptions import BTException
 from .device import BTDevice
 from . import settings
+
+logger = logging.getLogger(__name__)
 
 
 class BTManager:
@@ -53,7 +56,7 @@ class BTManager:
             raise BTException("A scan is already in progress")
 
         self.is_scanning = True
-        print("Scanning for BLE devices...")
+        logger.debug("Scanning for BLE devices...")
 
         device_local_storage = self.__get_device_local_storage()
         try:
@@ -61,7 +64,7 @@ class BTManager:
             self.devices = []
             for device in devices:
                 if not filter or device.name in settings.device_names:
-                    print(f"BLE device {device.name} found! Address: {device.address}")
+                    logger.debug(f"BLE device {device.name} found! Address: {device.address}")
                     self.devices.append(BTDevice(device))
 
             if store:
@@ -72,24 +75,24 @@ class BTManager:
                     f.write("\n".join(device.address))
 
             if not self.devices:
-                print("No BLE device found found...")
+                logger.debug("No BLE device found found...")
         finally:
             self.is_scanning = False
 
     async def pull_devices(self):
         """Load previously saved device information from the local file system."""
 
-        print("Pulling devices...")
+        logger.debug("Pulling devices...")
         self.devices = []
 
         device_local_storage = os.path.join(self.__get_device_local_storage(), "devices.txt")
 
         if not os.path.exists(device_local_storage):
-            print("Device local storage not setup")
+            logger.debug("Device local storage not setup")
             return
 
         with open(device_local_storage, "r") as f:
             devices = f.read().split("\n")
             for device in devices:
                 self.devices.append(BTDevice(device))
-                print(f"{device} pulled")
+                logger.debug(f"{device} pulled")


### PR DESCRIPTION
Logging is disabled by default but can be enabled when the environment variable PYGYW_LOGGING is set to something truthy (True, 1, etc.).

Logs look like this:
`2024-06-04 09:58:44,845 pygyw.bluetooth.manager MainThread DEBUG: Scanning for BLE devices...`