### PR TITLE
Remove the start_display method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.0.1:
+    - Remove the start_display method
+
 2.0.0:
     - Remove deprecated functionality
     - Encode positions on 2 bytes instead of 4

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ await device.connect()
 
 After the connection is established, you can display elements on the screen.
 
-:note: :note: Before actually displaying information, you need to manually indicate to the glasses that the screen needs to be turned on with the `start_display` method.
-
 ## Display
 
 To display elements on the aRdent glasses' screen, you need to create a `GYWDrawing` object and pass it to the `send_drawing(drawing)` method of the connected `BTDevice` object. There are three types of `GYWDrawing` objects:

--- a/example.py
+++ b/example.py
@@ -17,7 +17,6 @@ async def main():
     # device = BTDevice("AA:BB:CC:DD:EE:FF")
 
     await device.connect()
-    await device.start_display()
 
     await device.clear_screen(Colors.WHITE)
 

--- a/pygyw/bluetooth/commands.py
+++ b/pygyw/bluetooth/commands.py
@@ -18,7 +18,6 @@ class ControlCodes:
     A collection of control codes used by the GYW aRdent device to control the display.
 
     Attributes:
-        START_DISPLAY: Turn on the screen.
         DISPLAY_IMAGE: Send an image to the display.
         DISPLAY_TEXT: Send text to the display.
         CLEAR: Clear the screen.
@@ -30,7 +29,6 @@ class ControlCodes:
 
     """
 
-    START_DISPLAY = 0x01
     DISPLAY_IMAGE = 0x02
     DISPLAY_TEXT = 0x03
     CLEAR = 0x05

--- a/pygyw/bluetooth/device.py
+++ b/pygyw/bluetooth/device.py
@@ -154,21 +154,6 @@ class BTDevice:
         for drawing in drawings:
             await self.send_drawing(drawing)
 
-    async def start_display(self):
-        """
-        Turn the screen on.
-
-        ..note It has no effect if the screen is already on.
-
-        """
-
-        await self.__execute_commands([
-            commands.BTCommand(
-                commands.GYWCharacteristics.DISPLAY_COMMAND,
-                bytearray([commands.ControlCodes.START_DISPLAY]),
-            ),
-        ])
-
     async def set_contrast(self, value: float):
         """
         Set the screen contrast.


### PR DESCRIPTION
The screen gets powered on automatically, so `start_display` is no longer necessary.